### PR TITLE
fix(collectionview): add workaround for a uicollectionview bug to pre…

### DIFF
--- a/DataSource/DataSourceCellDescriptor.swift
+++ b/DataSource/DataSourceCellDescriptor.swift
@@ -82,6 +82,7 @@ extension CollectionViewDataSource {
 		}
 		collectionView.dataSource = self
 		self.collectionView = collectionView
+		collectionView.performBatchUpdates(nil)
 	}
 }
 

--- a/DataSourceTests/CollectionViewDataSourceTests.swift
+++ b/DataSourceTests/CollectionViewDataSourceTests.swift
@@ -21,7 +21,6 @@ class CollectionViewDataSourceTests: QuickSpecWithDataSets {
 			collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout())
 			let collectionViewDescriptors = [CellDescriptor(TestCollectionViewCell.reuseIdentifier, TestCellModel.self, .class(TestCollectionViewCell.self))]
 			collectionViewDataSource.configure(collectionView, using: collectionViewDescriptors)
-			collectionViewDataSource.dataSource.animatesChanges.value = false
 			collectionViewDataSource.dataSource.innerDataSource <~ dataSource.producer.map { $0 as DataSource }
 		}
 		itBehavesLike("CollectionViewDataSource object") { ["collectionViewDataSource": collectionViewDataSource, "TestCellModels": [self.dataSetWithTestCellModels], "collectionView": collectionView] }


### PR DESCRIPTION
This PR adds a workaround for the widely discussed UICollectionView bug (_'NSInternalInconsistencyException', reason: 'Invalid update: invalid number of sections...'_) which leads to immediate crash (i'm sure the most of you faced with that) in such simple code :
```
import Fueled_DataSource

final class TestCell: CollectionViewCell { }

final class TestViewController: UIViewController {
	@IBOutlet private var collectionView: UICollectionView!
	private let collectionViewDataSource = CollectionViewDataSource()

	override func viewDidLoad() {
		super.viewDidLoad()

		self.collectionViewDataSource.configure(self.collectionView,
			using: [CellDescriptor(TestCell.reuseIdentifier, String.self)])

		self.collectionViewDataSource.dataSource.innerDataSource.value = StaticDataSource(items: [""])
	}
}
```