### PR TITLE
fix(data-change-target): roll back to use begin/end updates instead o…

### DIFF
--- a/DataSource/TableView/TableViewChangeTarget.swift
+++ b/DataSource/TableView/TableViewChangeTarget.swift
@@ -12,13 +12,9 @@ import UIKit
 extension UITableView: DataChangeTarget {
 
 	public func ds_performBatchChanges(_ batchChanges: @escaping () -> Void) {
-		if #available(iOS 11.0, *) {
-			self.performBatchUpdates(batchChanges)
-		} else {
-			self.beginUpdates()
-			batchChanges()
-			self.endUpdates()
-		}
+		self.beginUpdates()
+		batchChanges()
+		self.endUpdates()
 	}
 
 	public func ds_deleteItems(at indexPaths: [IndexPath]) {


### PR DESCRIPTION
…f buggy performBatchUpdates.

@stephanecopin please consider rolling back to using deprecated begin/end update approach instead of the `performBatchUpdates` which is probably needs to be fixed later given some existing radars and other reports from many devs. 