### PR TITLE
fix(tableView/headerFooterDescriptor): fix HeaderFooterDescriptor's i…

### DIFF
--- a/DataSourceTests/TableViewDataSourceSharedConfiguration.swift
+++ b/DataSourceTests/TableViewDataSourceSharedConfiguration.swift
@@ -16,17 +16,19 @@ class TableViewDataSourceSharedConfiguration: QuickConfiguration {
 			describe("TableView tests") {
 				var tableViewDataSource: TableViewDataSource!
 				var initialData: [[TestCellModel]]!
+				var testSections: [DataSourceSection<TestCellModel>]!
 				var tableView: UITableView!
 				beforeEach {
 					tableViewDataSource = sharedExampleContext()["tableViewDataSource"] as? TableViewDataSource
 					initialData = sharedExampleContext()["TestCellModels"] as? [[TestCellModel]]
+					testSections = sharedExampleContext()["TestSections"] as? [DataSourceSection<TestCellModel>]
 					tableView = sharedExampleContext()["tableView"] as? UITableView
 				}
 				it("configure visible cells") {
 					tableViewDataSource.configureVisibleCells()
 				}
 				it("has correct number of section") {
-					expect(tableViewDataSource.numberOfSections(in: tableView)) == initialData.count
+					expect(tableViewDataSource.numberOfSections(in: tableView)) == testSections.map { $0.count } ?? 1
 				}
 				it("has correct number of items in sections") {
 					for index in initialData.indices {

--- a/DataSourceTests/TableViewDataSourceTests.swift
+++ b/DataSourceTests/TableViewDataSourceTests.swift
@@ -15,14 +15,29 @@ class TableViewDataSourceTests: QuickSpecWithDataSets {
 	override func spec() {
 		var tableViewDataSource: TableViewDataSource!
 		var tableView: UITableView!
+		let testSections = [
+			DataSourceSection(items: self.dataSetWithTestCellModels),
+			DataSourceSection(items: self.dataSetWithTestCellModels2)
+		]
 		beforeEach {
-			let dataSource = Property(value: StaticDataSource(sections: [DataSourceSection(items: self.dataSetWithTestCellModels), DataSourceSection(items: self.dataSetWithTestCellModels2)]))
+			let dataSource = Property(
+				value: StaticDataSource(
+					sections: testSections
+				)
+			)
 			tableViewDataSource = TableViewDataSource()
 			tableView = UITableView(frame: CGRect.zero)
 			let tableViewDescriptors = [CellDescriptor(TestTableViewCell.reuseIdentifier, TestCellModel.self, .class(TestTableViewCell.self))]
 			tableViewDataSource.configure(tableView, using: tableViewDescriptors)
 			tableViewDataSource.dataSource.innerDataSource <~ dataSource.producer.map { $0 as DataSource }
 		}
-		itBehavesLike("TableViewDataSource object") { ["tableViewDataSource": tableViewDataSource!, "TestCellModels": [self.dataSetWithTestCellModels, self.dataSetWithTestCellModels2], "tableView": tableView!] }
+		itBehavesLike("TableViewDataSource object") {
+			[
+				"tableViewDataSource": tableViewDataSource!,
+				"TestCellModels": [self.dataSetWithTestCellModels, self.dataSetWithTestCellModels2],
+				"TestSections": testSections,
+				"tableView": tableView!
+			]
+		}
 	}
 }

--- a/DataSourceTests/TableViewDataSourceWithHeaderFooterTitlesTests.swift
+++ b/DataSourceTests/TableViewDataSourceWithHeaderFooterTitlesTests.swift
@@ -15,12 +15,11 @@ class TableViewDataSourceWithHeaderFooterTitlesTests: QuickSpecWithDataSets {
 	override func spec() {
 		var tableViewDataSource: TableViewDataSourceWithHeaderFooterTitles!
 		var tableView: UITableView!
-		var headerTitle: String!
-		var footerTitle: String!
+		let headerTitle = "headerTitle"
+		let footerTitle = "footerTitle"
+		let headerSection = DataSourceSection(items: self.dataSetWithTestCellModels, supplementaryItems: [UICollectionView.elementKindSectionHeader: headerTitle, UICollectionView.elementKindSectionFooter: footerTitle])
 		beforeEach {
-			headerTitle = "headerTitle"
-			footerTitle = "footerTitle"
-			let headerSection = DataSourceSection(items: self.dataSetWithTestCellModels, supplementaryItems: [UICollectionView.elementKindSectionHeader: headerTitle!, UICollectionView.elementKindSectionFooter: footerTitle!])
+
 			let dataSource = Property(value: StaticDataSource(sections: [headerSection]))
 			tableViewDataSource = TableViewDataSourceWithHeaderFooterTitles()
 			tableView = UITableView(frame: CGRect.zero)
@@ -28,7 +27,14 @@ class TableViewDataSourceWithHeaderFooterTitlesTests: QuickSpecWithDataSets {
 			tableViewDataSource.configure(tableView, using: tableViewDescriptors)
 			tableViewDataSource.dataSource.innerDataSource <~ dataSource.producer.map { $0 as DataSource }
 		}
-		itBehavesLike("TableViewDataSource object") { ["tableViewDataSource": tableViewDataSource!, "TestCellModels": [self.dataSetWithTestCellModels], "tableView": tableView!] }
+		itBehavesLike("TableViewDataSource object") {
+			[
+				"tableViewDataSource": tableViewDataSource!,
+				"TestCellModels": [self.dataSetWithTestCellModels],
+				"TestSections": [headerSection],
+				"tableView": tableView!
+			]
+		}
 		it("has correct header") {
 			expect(tableViewDataSource.tableView(tableView, titleForHeaderInSection: 0)) == headerTitle
 		}

--- a/DataSourceTests/TableViewDataSourceWithHeaderFooterViewsTests.swift
+++ b/DataSourceTests/TableViewDataSourceWithHeaderFooterViewsTests.swift
@@ -15,28 +15,65 @@ class TableViewDataSourceWithHeaderFooterViewsTests: QuickSpecWithDataSets {
 	override func spec() {
 		var tableViewDataSource: TableViewDataSourceWithHeaderFooterViews!
 		var tableView: UITableView!
-		beforeEach {
-			let headerFooterView = TestHeaderFooterViewModel()
-			let headerSection = DataSourceSection(
+
+		let testSections = [
+			DataSourceSection(
 				items: self.dataSetWithTestCellModels,
-				supplementaryItems: [UICollectionView.elementKindSectionHeader: headerFooterView, UICollectionView.elementKindSectionFooter: headerFooterView])
-			let dataSource = Property(value: StaticDataSource(sections: [headerSection]))
+				supplementaryItems: [
+					UICollectionView.elementKindSectionHeader: TestHeaderFirstViewModel(),
+					UICollectionView.elementKindSectionFooter: TestFooterFirstViewModel()
+				]
+			),
+			DataSourceSection(
+				items: self.dataSetWithTestCellModels,
+				supplementaryItems: [
+					UICollectionView.elementKindSectionHeader: TestHeaderSecondViewModel(),
+					UICollectionView.elementKindSectionFooter: TestFooterSecondViewModel()
+				]
+			),
+		]
+
+		beforeEach {
+			let dataSource = Property(
+				value: StaticDataSource(
+					sections: testSections
+				)
+			)
 			tableViewDataSource = TableViewDataSourceWithHeaderFooterViews()
 			tableView = UITableView(frame: CGRect.zero)
-			let tableViewDescriptors = [CellDescriptor(TestTableViewCell.reuseIdentifier, TestCellModel.self, .class(TestTableViewCell.self))]
+			let cellDescriptors = [
+				CellDescriptor(TestTableViewCell.reuseIdentifier, TestCellModel.self, .class(TestTableViewCell.self))
+			]
 			tableViewDataSource.configure(
 				tableView,
-				using: tableViewDescriptors,
-				headerDescriptor: HeaderFooterDescriptor(TestHeaderFooterView.reuseIdentifier, TestHeaderFooterViewModel.self, .class(TestHeaderFooterView.self)),
-				footerDescriptor: HeaderFooterDescriptor(TestHeaderFooterView.reuseIdentifier, TestHeaderFooterViewModel.self, .class(TestHeaderFooterView.self)))
+				using: cellDescriptors,
+				headerDescriptors: [
+					HeaderFooterDescriptor(TestHeaderFirstView.reuseIdentifier, TestHeaderFirstViewModel.self, .class(TestHeaderFirstView.self)),
+					HeaderFooterDescriptor(TestHeaderSecondView.reuseIdentifier, TestHeaderSecondViewModel.self, .class(TestHeaderSecondView.self)),
+				],
+				footerDescriptors: [
+					HeaderFooterDescriptor(TestFooterFirstView.reuseIdentifier, TestFooterFirstViewModel.self, .class(TestFooterFirstView.self)),
+					HeaderFooterDescriptor(TestFooterSecondView.reuseIdentifier, TestFooterSecondViewModel.self, .class(TestFooterSecondView.self)),
+				]
+			)
 			tableViewDataSource.dataSource.innerDataSource <~ dataSource.producer.map { $0 as DataSource }
 		}
-		itBehavesLike("TableViewDataSource object") { ["tableViewDataSource": tableViewDataSource!, "TestCellModels": [self.dataSetWithTestCellModels], "tableView": tableView!] }
+
+		itBehavesLike("TableViewDataSource object") {
+			[
+				"tableViewDataSource": tableViewDataSource!,
+				"TestCellModels": [self.dataSetWithTestCellModels],
+				"TestSections": testSections,
+				"tableView": tableView!
+			]
+		}
 		it("has header") {
-			 expect(tableViewDataSource.tableView(tableView, viewForHeaderInSection: 0)).notTo(beNil())
+			expect(tableViewDataSource.tableView(tableView, viewForHeaderInSection: 0)).to(beAKindOf(TestHeaderFirstView.self))
+			expect(tableViewDataSource.tableView(tableView, viewForHeaderInSection: 1)).to(beAKindOf(TestHeaderSecondView.self))
 		}
 		it("has footer") {
-			expect(tableViewDataSource.tableView(tableView, viewForFooterInSection: 0)).notTo(beNil())
+			expect(tableViewDataSource.tableView(tableView, viewForFooterInSection: 0)).to(beAKindOf(TestFooterFirstView.self))
+			expect(tableViewDataSource.tableView(tableView, viewForFooterInSection: 1)).to(beAKindOf(TestFooterSecondView.self))
 		}
 	}
 }

--- a/DataSourceTests/TestCells.swift
+++ b/DataSourceTests/TestCells.swift
@@ -14,6 +14,18 @@ final class TestTableViewCell: TableViewCell, ReusableItem  { }
 
 final class TestCollectionViewCell: CollectionViewCell, ReusableItem { }
 
-struct TestHeaderFooterViewModel { }
+struct TestHeaderFirstViewModel { }
 
-final class TestHeaderFooterView: TableViewHeaderFooterView, ReusableItem { }
+final class TestHeaderFirstView: TableViewHeaderFooterView, ReusableItem { }
+
+struct TestHeaderSecondViewModel { }
+
+final class TestHeaderSecondView: TableViewHeaderFooterView, ReusableItem { }
+
+struct TestFooterFirstViewModel { }
+
+final class TestFooterFirstView: TableViewHeaderFooterView, ReusableItem { }
+
+struct TestFooterSecondViewModel { }
+
+final class TestFooterSecondView: TableViewHeaderFooterView, ReusableItem { }


### PR DESCRIPTION
* fixed `HeaderFooterDescriptor`'s `isMatching` signature to use section number instead of IndexPath. 
* modified `configure` method of the `TableViewDataSourceWithHeaderFooterViews` to allow registration of multiple headers and footers. 
* fixed tests.